### PR TITLE
fix_redundant_space

### DIFF
--- a/code_book/ch4.md
+++ b/code_book/ch4.md
@@ -81,7 +81,6 @@ And here's the code that generated figure 4.2.
 
 ```{code-cell} ipython3
 
-
 def draw_trajectory(x, y, ax, n=10):
     """
     Draw the trajectory of length n starting from (x, y).
@@ -144,7 +143,6 @@ As in the textbook, let's plot a trajectory starting from 0.11.
 
 
 ```{code-cell} ipython3
-
 
 q = DS(h=lambda x: 4 * x * (1 - x), x=0.11)
 t = q.trajectory(200)


### PR DESCRIPTION
Hi @jstac ,

This is just a small PR. 

When I download ipynb file from the code book, the two python codes had redundant space in the beginning of the codes like below. I just get rid of the space from md file. 

<img width="943" alt="Screen Shot 2021-09-10 at 9 21 33 pm" src="https://user-images.githubusercontent.com/44494439/132936064-8afef9a1-6e25-429d-9427-55a1dddb8293.png">
<img width="948" alt="Screen Shot 2021-09-10 at 9 21 47 pm" src="https://user-images.githubusercontent.com/44494439/132936067-c93dcbf8-9611-43d8-bffe-1d4d8c6bfa72.png">
