### PR TITLE
remove_redundant_rstring

### DIFF
--- a/code_book/ch4.md
+++ b/code_book/ch4.md
@@ -236,7 +236,7 @@ while r < 4:
     ax.plot([r] * len(t), t, 'k.', ms=0.4)
     r = r + 0.005
 
-ax.set_xlabel(r'$r$', fontsize=16)
+ax.set_xlabel('$r$', fontsize=16)
 plt.show()
 
 ```


### PR DESCRIPTION
Hi @jstac ,

I just get rid of a redundant rstring from "ax.set_xlabel(**r**'$r$', fontsize=16)".