### PR TITLE
[chapter6] change parameter to be same as pdf

### DIFF
--- a/code_book/ch6.md
+++ b/code_book/ch6.md
@@ -79,7 +79,7 @@ capital.
 ```{code-cell} ipython3
 
 @jit
-def sim_from_marginal(t=10, init=1, sim_size=100_000, params=default_params):
+def sim_from_marginal(t=10, init=1, sim_size=1000, params=default_params):
     k_draws = np.empty(sim_size)
     for i in range(sim_size):
         k = init


### PR DESCRIPTION
Hi @jstac ,

This is just a small PR about parameter. In exercise 6.2, n = 1000 as follows. I change the sim_size to 1000 in order to make it same as pdf.
<img width="522" alt="Screen Shot 2021-09-11 at 9 38 28 am" src="https://user-images.githubusercontent.com/44494439/132954951-a0a6e70e-fd19-4350-9578-e8d4574a3728.png">

