### PR TITLE
[chapter6] fix typo

### DIFF
--- a/code_book/ch6.md
+++ b/code_book/ch6.md
@@ -211,7 +211,7 @@ plt.show()
 
 Our next task is to simulate from the "threshold exernalities" model.
 
-The following code generates figures 6.5 and 6.6.
+The following code generates figures 6.6 and 6.7.
 
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Hi @jstac ,

I just fix a typo. This code generates those two figures below in textbook, which is figure 6.6 and 6.7.
<img width="372" alt="Screen Shot 2021-09-11 at 9 47 17 am" src="https://user-images.githubusercontent.com/44494439/132955181-c123610e-e004-452c-b991-3a48a1e34b52.png">
<img width="347" alt="Screen Shot 2021-09-11 at 9 47 28 am" src="https://user-images.githubusercontent.com/44494439/132955185-b9825f02-f935-4986-989e-75857208e9e1.png">
