### PR TITLE
[chapter6]fix typo about sigma

### DIFF
--- a/code_book/ch6.md
+++ b/code_book/ch6.md
@@ -800,7 +800,7 @@ def T_sigma(v, sigma, os):
 ```
 
 To compute the policy value we iterate until convergence, starting
-from some guess of $v_sigma$ represented by `v_guess`.
+from some guess of $v_\sigma$ represented by `v_guess`.
 
 ```{code-cell} ipython3
 def compute_policy_value(os,


### PR DESCRIPTION
Hi @jstac ,

This PR fixes a typo in code book like below.

<img width="718" alt="Screen Shot 2021-09-11 at 10 31 07 am" src="https://user-images.githubusercontent.com/44494439/132956243-60609ac5-3843-4476-97c0-d4c4eac0bf11.png">
