### PR TITLE
FIX: code errata reported by Diasuke Nakamura

### DIFF
--- a/code_book/_config.yml
+++ b/code_book/_config.yml
@@ -5,30 +5,31 @@ logo: logo.png
 
 
 sphinx:
-    config:
-        mathjax_config:
-            TeX:
-                Macros:
-                    "Exp" : ["\\operatorname{Exp}"]
-                    "Binomial" : ["\\operatorname{Binomial}"]
-                    "Poisson" : ["\\operatorname{Poisson}"]
-                    "BB" : ["\\mathbb{B}"]
-                    "EE" : ["\\mathbb{E}"]
-                    "PP" : ["\\mathbb{P}"]
-                    "RR" : ["\\mathbb{R}"]
-                    "NN" : ["\\mathbb{N}"]
-                    "ZZ" : ["\\mathbb{Z}"]
-                    "dD" : ["\\mathcal{D}"]
-                    "fF" : ["\\mathcal{F}"]
-                    "lL" : ["\\mathcal{L}"]
-                    "linop" : ["\\mathcal{L}(\\mathbb{B})"]
-                    "linopell" : ["\\mathcal{L}(\\ell_1)"]
+  config:
+    mathjax3_config:
+      tex:
+        macros:
+          "Exp" : ["\\operatorname{Exp}"]
+          "Binomial" : ["\\operatorname{Binomial}"]
+          "Poisson" : ["\\operatorname{Poisson}"]
+          "BB" : ["\\mathbb{B}"]
+          "EE" : ["\\mathbb{E}"]
+          "PP" : ["\\mathbb{P}"]
+          "RR" : ["\\mathbb{R}"]
+          "NN" : ["\\mathbb{N}"]
+          "ZZ" : ["\\mathbb{Z}"]
+          "dD" : ["\\mathcal{D}"]
+          "fF" : ["\\mathcal{F}"]
+          "lL" : ["\\mathcal{L}"]
+          "linop" : ["\\mathcal{L}(\\mathbb{B})"]
+          "linopell" : ["\\mathcal{L}(\\ell_1)"]
+    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js                    
 
 execute:
-    execute_notebooks: cache
-    timeout: -1
+  execute_notebooks: cache
+  timeout: -1
 
 latex:
-    latex_engine: "xelatex"
-    latex_documents:
-        targetname: book.tex
+  latex_engine: "xelatex"
+  latex_documents:
+    targetname: book.tex

--- a/code_book/ch6.md
+++ b/code_book/ch6.md
@@ -496,8 +496,8 @@ class AD:
         return a * b
 
     def p(self, x, y):
-        z = y / (self.s * self.A(x) * self.f(x))
-        return self.phi(z) / z
+        z = self.s * self.A(x) * self.f(x)
+        return self.phi(y/z) / z
         
 ```
 

--- a/code_book/ch6.md
+++ b/code_book/ch6.md
@@ -522,7 +522,7 @@ for sigma, g in zip(sigmas, greys):
             color=g, 
             lw=2, 
             alpha=0.6,
-            label=f'$\sigma={sigma}$')
+            label=rf'$\sigma={sigma}$')
 
 ax.set_xlabel('$k$')
 ax.legend()


### PR DESCRIPTION
Fixes errata based on feedback

```
As for the exercise 6.16, your python code solution

 

    def p(self, x, y):

        z = y / (self.s * self.A(x) * self.f(x))

        return self.phi(z) / z

 

seems to include “y” twice. However, EDTC eq.6.15 does not include outside of \phi.

I guess it should be

 

    def p(self, x, y):

        z =  (self.s * self.A(x) * self.f(x))

        return self.phi(y/z) / z
```