### PR TITLE
FIX: string syntax updates

### DIFF
--- a/code_book/ch11.md
+++ b/code_book/ch11.md
@@ -100,7 +100,7 @@ for lda, lt in zip(lambdas, line_type):
     def ecdf(y):
         return sum(obs <= y) / mc_size
     yvec = [ecdf(x) for x in xvec]
-    ax.plot(xvec, yvec, lt, label=f'$\\lambda={lda}$')
+    ax.plot(xvec, yvec, lt, label=rf'$\lambda={lda}$')
 
 ax.set_xlabel('capital')
 ax.legend()
@@ -130,8 +130,8 @@ for i, lda in enumerate(lambdas):
     prob_at_b[i] = np.mean(obs == b)
 
 fig, ax = plt.subplots()
-ax.plot(lambdas, prob_at_b, label='$\\psi^*(\{b\})$')
-ax.set_xlabel('$\\lambda$')
+ax.plot(lambdas, prob_at_b, label=r'$\psi^*({b})$')
+ax.set_xlabel(r'$\lambda$')
 ax.legend()
 
 plt.show()

--- a/code_book/ch6.md
+++ b/code_book/ch6.md
@@ -314,7 +314,7 @@ axes = axes.flatten()
 for delta, ax in zip(deltas, axes):
     f = kde_factory(Y, delta)
     ax.plot(x_grid, f(x_grid))
-    ax.set_title(f"$\delta_n = {delta}$")
+    ax.set_title(rf"$\delta_n = {delta}$")
 
 plt.tight_layout()
 #plt.savefig("kdes.pdf")


### PR DESCRIPTION
This PR fixes up some minor string syntax updates to `python` and prevents warning messages from `matplotlib`