### PR TITLE
FIX: timing for discount in ch4

### DIFF
--- a/code_book/ch4.md
+++ b/code_book/ch4.md
@@ -480,9 +480,9 @@ Q = np.identity(3)
 
 for t in T_vals:
     Q = Q @ p_H
-    discount = discount * rho
     current_profits += discount * np.inner(psi, Q @ h)
     profits.append(current_profits)
+    discount = discount * rho
 
 fig, ax = plt.subplots()
 ax.plot(profits, label='profits')


### PR DESCRIPTION
@jstac this updates the timing in the code for Chapter 4 exercise `4.36` as per email reported by Alexander

---

I moved the discount update below the computation to adjust the timing, rather than update the initial condition. 